### PR TITLE
Adds Ability To Pass In More OneSignal Options For Init

### DIFF
--- a/package/src/oneSignal.ts
+++ b/package/src/oneSignal.ts
@@ -40,12 +40,13 @@ const mapOptionsObject = (o: any, indent: number = 0) => {
 /**
  * Provides the module script content to inject.
  */
-const getModuleScriptBody = (options: OneSignalOptions) => {
+const getModuleScriptBody = (appId: string, options: OneSignalOptions) => {
   let mappedOptions = mapOptionsObject(options);
   return `
     var OneSignal = window.OneSignal || [];
     OneSignal.push(function() {
       OneSignal.init({
+        appId: "${appId}",
         ${mappedOptions}
       });
     });
@@ -103,9 +104,9 @@ const injectBaseScript = () => {
 /**
  * Injects the module script for OneSignal
  */
-const injectModuleScript = (options: OneSignalOptions) => {
+const injectModuleScript = (appId: string, options: OneSignalOptions) => {
   injectScript(DEFAULT_MODULE_SCRIPT_ID, (script) => {
-    script.innerHTML = getModuleScriptBody(options);
+    script.innerHTML = getModuleScriptBody(appId, options);
     script.async = true;
 
     return script;
@@ -115,8 +116,8 @@ const injectModuleScript = (options: OneSignalOptions) => {
 /**
  * Initializes OneSignal.
  */
-const initialize = (options: OneSignalOptions) => {
-  if (!options.appId) {
+const initialize = (appId: string, options: OneSignalOptions) => {
+  if (!appId) {
     throw new Error('You need to provide your OneSignal appId.');
   }
 
@@ -125,7 +126,7 @@ const initialize = (options: OneSignalOptions) => {
   }
 
   injectBaseScript();
-  injectModuleScript(options);
+  injectModuleScript(appId, options);
 };
 
 /**

--- a/package/src/oneSignal.ts
+++ b/package/src/oneSignal.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-unused-vars
-import { IOneSignal } from './oneSignal.types';
+import { IOneSignal, OneSignalOptions } from './oneSignal.types';
 
 const DEFAULT_BASE_SCRIPT_ID = 'react-onesignal-base';
 
@@ -11,19 +11,46 @@ const DEFAULT_MODULE_SCRIPT_ID = 'react-onesignal-module';
 const ONE_SIGNAL_SCRIPT_SRC = 'https://cdn.onesignal.com/sdks/OneSignalSDK.js';
 
 /**
+ * Maps The Options Object Into A String For The Module Script
+ * @param o the options object
+ * @param indent 
+ */
+const mapOptionsObject = (o: any, indent: number = 0) => {
+  var out = '';
+  for (var p in o) {
+      if (o.hasOwnProperty(p)) {
+          var val = o[p];
+          out += new Array(4 * indent + 1).join(' ') + p + ': ';
+          if (typeof val === 'object') {
+            out += '{\n' + mapOptionsObject(val, indent + 1) + new Array(4 * indent + 1).join(' ') + '}';
+          } else if (typeof val === 'function') {
+
+          } else if (typeof val === 'boolean') {
+            out += val;
+          }
+          else {
+            out += '"' + val + '"';
+          }
+          out += ',\n';
+      }
+  }
+  return out;
+}
+
+/**
  * Provides the module script content to inject.
  */
-const getModuleScriptBody = (appId: string, showNotifyButton: boolean) => `
-  var OneSignal = window.OneSignal || [];
-  OneSignal.push(function() {
-    OneSignal.init({
-      appId: "${appId}",
-      notifyButton: {
-        enable: ${showNotifyButton},
-      },
+const getModuleScriptBody = (options: OneSignalOptions) => {
+  let mappedOptions = mapOptionsObject(options);
+  return `
+    var OneSignal = window.OneSignal || [];
+    OneSignal.push(function() {
+      OneSignal.init({
+        ${mappedOptions}
+      });
     });
-  });
-`;
+  `
+};
 
 /**
  * Gets the window OneSignal instance.
@@ -76,9 +103,9 @@ const injectBaseScript = () => {
 /**
  * Injects the module script for OneSignal
  */
-const injectModuleScript = (appId: string, showNotifyButton: boolean) => {
+const injectModuleScript = (options: OneSignalOptions) => {
   injectScript(DEFAULT_MODULE_SCRIPT_ID, (script) => {
-    script.innerHTML = getModuleScriptBody(appId, showNotifyButton);
+    script.innerHTML = getModuleScriptBody(options);
     script.async = true;
 
     return script;
@@ -88,11 +115,8 @@ const injectModuleScript = (appId: string, showNotifyButton: boolean) => {
 /**
  * Initializes OneSignal.
  */
-const initialize = (
-  appId: string,
-  showNotifyButton: boolean = false,
-) => {
-  if (!appId) {
+const initialize = (options: OneSignalOptions) => {
+  if (!options.appId) {
     throw new Error('You need to provide your OneSignal appId.');
   }
 
@@ -101,7 +125,7 @@ const initialize = (
   }
 
   injectBaseScript();
-  injectModuleScript(appId, showNotifyButton);
+  injectModuleScript(options);
 };
 
 /**

--- a/package/src/oneSignal.types.ts
+++ b/package/src/oneSignal.types.ts
@@ -9,7 +9,6 @@ export interface IOneSignal {
 }
 
 export interface OneSignalOptions {
-  appId: string;
   subdomainName?: string;
   allowLocalhostAsSecureOrigin?: boolean;
   requiresUserPrivacyConsent?: boolean;

--- a/package/src/oneSignal.types.ts
+++ b/package/src/oneSignal.types.ts
@@ -7,3 +7,21 @@ export interface IOneSignal {
   getUserId: () => Promise<string>,
   initialized: boolean,
 }
+
+export interface OneSignalOptions {
+  appId: string;
+  subdomainName?: string;
+  allowLocalhostAsSecureOrigin?: boolean;
+  requiresUserPrivacyConsent?: boolean;
+  persistNotification?: boolean;
+  autoResubscribe?: boolean;
+  autoRegister?: boolean;
+  notificationClickHandlerMatch?: string;
+  notificationClickHandlerAction?: string;
+  notifyButton?: {
+    enable?: boolean;
+    size?: 'small' | 'medium' | 'large';
+    position?: 'bottom-left' | 'bottom-right';
+    showCredit?: boolean;
+  }
+}


### PR DESCRIPTION
Hello, Thanks for this package. I've been looking for something like this and I'm glad I've found it. 

I needed to pass in some additional options to the OneSignal Initializer to get it working with my setup.

I refactored the code so that instead of just passing in **appId** and **showNotifyButton** you could now pass in an **Options** object based on the [OneSignal Init Parameters](https://documentation.onesignal.com/docs/web-push-sdk#section--key-h-289-ref-null-props-children-init-classname-lang-meta-_owner-null-).

I also added the **Types** for this. I only included the basic **string** and **boolean** parameters since those are the only ones I needed at the moment.

Thanks again for your initial work and I hope my contribution can be helpful.