### PR TITLE
Event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,54 @@ OneSignal.setExternalUserId('your_id');
 const externalUserId = await OneSignal.getExternalUserId();
 ```
 
+## Events and Event Listeners
+You can also listen for native OneSignal events like `subscriptionChange`.
+
+To add an event listener to the `OneSignal.push()` array, pass an array of events to the `ReactOneSignal.initialize()` function as the third parameter.
+
+Each object in the array should contain:  
+* `listener` -- (optional) Default value: `'on'`.
+Some events can be listened for via multiple listeners (e.g. `.on()`, `.once()`).
+[Check the docs](https://documentation.onesignal.com/docs/web-push-sdk) to see which listeners listen for your event.  
+Example: `'on'` | `'once'`
+
+* `event` -- Name of the event being listened for.  
+Example: `'subscriptionChange'`
+
+* `callback` -- Callback function for event.  
+Example: `(value) => { console.log(value); }`
+
+For documentation on events and event listeners, check out the [Web Push SDK docs](https://documentation.onesignal.com/docs/web-push-sdk).
+
+```js
+const events = [
+  {
+    listener: 'once',
+    event: 'subscriptionChange',
+    callback: (isSubscribed) => {
+      if (true === isSubscribed) {
+        console.log('The user subscription state is now:', isSubscribed);
+      }
+    },
+  },
+  {
+    event: 'notificationDisplay',
+    callback: (event) => {
+      console.warn('OneSignal notification displayed:', event);
+    },
+  },
+  {
+    event: 'notificationDismiss',
+    callback: (event) => {
+      console.warn('OneSignal notification dismissed:', event);
+    },
+  },
+];
+
+
+ReactOneSignal.initialize(applicationId, options, events);
+```
+
 ## Contributing
 
 Pull requests are welcome! If you have any feedback, issue or suggestion, feel free to open [a new issue](https://github.com/pedro-lb/react-onesignal/issues/new) so we can talk about it 💬.

--- a/package/src/oneSignal.ts
+++ b/package/src/oneSignal.ts
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-unused-vars
 import {
   IOneSignal,
   OneSignalOptions,
@@ -85,7 +84,7 @@ const getModuleScriptBody = (appId: string, options: OneSignalOptions, events: I
 };
 
 /**
- * Take our object of events, and build OneSignal listeners.
+ * Take our object of OneSignal events and construct listeners.
  *
  * @param eventsArr Array of event/callback key/value pairs defined by IOneSignalEvent interface.
  * @return string Script snippet for injecting into the native OneSignal.push()  method.
@@ -96,8 +95,8 @@ const buildEventListeners = (eventsArr: IOneSignalEvent[]) => {
   // Let's make sure we've got an array that isn't empty.
   if (Array.isArray(eventsArr) && eventsArr.length) {
     eventsArr.forEach(event => {
-      // console.log(eventName)
-      returnStr += `OneSignal.on('${event.name}', ${event.callback});`
+      event.listener = event.listener || 'on';
+      returnStr += `OneSignal.${event.listener}('${event.event}', ${event.callback});`
     });
   }
   return returnStr;
@@ -166,7 +165,7 @@ const injectModuleScript = (appId: string, options: OneSignalOptions, events: IO
 /**
  * Initializes OneSignal.
  */
-const initialize = (appId: string, options: OneSignalOptions, events: IOneSignalEvent[]) => {
+const initialize = (appId: string, options: OneSignalOptions, events: IOneSignalEvent[] = []) => {
   if (!appId) {
     throw new Error('You need to provide your OneSignal appId.');
   }

--- a/package/src/oneSignal.types.ts
+++ b/package/src/oneSignal.types.ts
@@ -28,10 +28,11 @@ export interface OneSignalOptions {
 }
 
 export interface IOneSignalEventCallback{
-  callback?: (result: any) => boolean
+  callback: (result: any) => any
 }
 
 export interface IOneSignalEvent {
-  name: string;
+  listener?: string;
+  event: string;
   callback: IOneSignalEventCallback
 }

--- a/package/src/oneSignal.types.ts
+++ b/package/src/oneSignal.types.ts
@@ -26,3 +26,12 @@ export interface OneSignalOptions {
     showCredit?: boolean;
   }
 }
+
+export interface IOneSignalEventCallback{
+  callback?: (result: any) => boolean
+}
+
+export interface IOneSignalEvent {
+  name: string;
+  callback: IOneSignalEventCallback
+}


### PR DESCRIPTION
This commit resolves #2 , by adding a new optional `events` array for building event listeners and their callbacks into the injected js snippet within the `OneSignal.push()` function.

Each event object contains `listener` (optional), `event`, and `callback` as defined in the interface. The array is itereated over, and each event/callback is wrapped in the chosen `listener` (`.on()`, `.once()`, etc.).

Tested locally with several events and behaving as expected.