### PR TITLE
Add options

### DIFF
--- a/package/src/oneSignal.ts
+++ b/package/src/oneSignal.ts
@@ -23,7 +23,7 @@ const mapOptionsObject = (options: any, indent: number = 0) => {
   const optionKeys = Object.keys(options || {});
 
   for (let index = 0; index < optionKeys.length; index += 1) {
-    const key = optionKeys[index];
+    let key = optionKeys[index];
 
     const hasOwnProperty = Object.prototype.hasOwnProperty.call(options, key);
 
@@ -36,6 +36,10 @@ const mapOptionsObject = (options: any, indent: number = 0) => {
     // Functions are not supported, so we'll ignore them
     if (typeof option === 'function') {
       continue;
+    }
+
+    if (key.includes('.')) {
+      key = `"${key}"`
     }
 
     result += `${new Array(TABS_LENGTH * indent + 1).join(' ') + key}: `;

--- a/package/src/oneSignal.types.ts
+++ b/package/src/oneSignal.types.ts
@@ -27,6 +27,19 @@ export interface OneSignalOptions {
     size?: 'small' | 'medium' | 'large';
     position?: 'bottom-left' | 'bottom-right';
     showCredit?: boolean;
+    prenotify?: boolean;
+    theme?: 'default' | 'inverse';
+    offset?: {
+      bottom?: string;
+      right?: string;
+      left?: string;
+    },
+    text?: {
+      [key: string]: string;
+    };
+    colors?: {
+      [key: string]: string;
+    };
   }
 }
 

--- a/package/src/oneSignal.types.ts
+++ b/package/src/oneSignal.types.ts
@@ -13,6 +13,7 @@ export interface IOneSignal {
 }
 
 export interface OneSignalOptions {
+  safari_web_id?: string,
   subdomainName?: string;
   allowLocalhostAsSecureOrigin?: boolean;
   requiresUserPrivacyConsent?: boolean;


### PR DESCRIPTION
This commit add safari support and new options for bell prompt. 
Options added : 
- `safari_web_id`
- `prenotify`
- `theme`
- `offset`
- `text`
- `colors`