### PR TITLE
Feat/add setup one signal hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,30 @@ const keyValues = {
 OneSignal.sendTags(keyValues);
 ```
 
+### Setup hook
+
+To avoid error due to OneSignal not initialized, you can use useOneSignalSetup hook, passing a callback to be called when OneSignal is ready
+
+```ts
+import OneSignal, { useOneSignalSetup } from 'react-onesignal';
+
+type AppProps = {
+  user: {
+    id: string;
+    Email: string;
+  };
+};
+
+function App(props: AppProps) {
+  const {user} = props;
+  const isOneSignalRunning = process.env.NODE_ENV === 'production';
+  useOneSignalSetup(() => {
+    OneSignal.setEmail(user.Email);
+    OneSignal.setExternalUserId(user.id);
+  }, isOneSignalRunning ? 100 : null);
+}
+```
+
 ## Contributing
 
 Pull requests are welcome! If you have any feedback, issue or suggestion, feel free to open [a new issue](https://github.com/pedro-lb/react-onesignal/issues/new) so we can talk about it 💬.

--- a/package/package.json
+++ b/package/package.json
@@ -18,7 +18,9 @@
     "copy_publish_files": "cp ../README.md .",
     "prepublish": "yarn run build && yarn run copy_publish_files"
   },
-  "peerDependencies": {},
+  "peerDependencies": {
+    "react": "16.x.x"
+  },
   "devDependencies": {
     "@babel/core": "^7.0.0",
     "@babel/plugin-external-helpers": "^7.0.0",

--- a/package/package.json
+++ b/package/package.json
@@ -19,7 +19,7 @@
     "prepublish": "yarn run build && yarn run copy_publish_files"
   },
   "peerDependencies": {
-    "react": "16.x.x"
+    "react": ">= 16.8"
   },
   "devDependencies": {
     "@babel/core": "^7.0.0",

--- a/package/src/hooks.ts
+++ b/package/src/hooks.ts
@@ -1,0 +1,24 @@
+import { useEffect, useRef } from 'react';
+
+// custom hook inspired by Dan Abramov. https://overreacted.io/making-setinterval-declarative-with-react-hooks/
+// eslint-disable-next-line import/prefer-default-export
+export function useInterval(callback: () => void, delay: number | null) {
+  const savedCallback = useRef<() => void>();
+
+  // Remember the latest callback.
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  // Set up the interval.
+  useEffect(() => {
+    if (delay !== null && savedCallback.current) {
+      const tick = () => {
+        savedCallback.current!();
+      };
+      const id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+    return () => {};
+  }, [delay]);
+}

--- a/package/src/oneSignal.ts
+++ b/package/src/oneSignal.ts
@@ -1,5 +1,8 @@
 // eslint-disable-next-line no-unused-vars
+import { useState } from 'react';
 import { IOneSignal, OneSignalOptions, IOneSignalEvent } from './oneSignal.types';
+
+import { useInterval } from './hooks';
 
 const DEFAULT_BASE_SCRIPT_ID = 'react-onesignal-base';
 
@@ -462,6 +465,25 @@ const sendTags = (keyValues: object) => new Promise<string>((resolve, reject) =>
 });
 
 /**
+ * hook that waits for oneSignal initialization before executing the callback
+ * usefull for using setEmail and setExternalUserId without getting error
+ * it uses setInterval to check if OneSignal is setup, calling the callback when it is
+ *
+ * @param callback the callback to be called when oneSignal is initilized
+ * @param pollingIntervalMs time beetween checks, null to disable in development
+ */
+export const useOneSignalSetup = (callback: () => void, pollingIntervalMs: number | null = 100) => {
+  const [initialized, setInitialized] = useState(false);
+  useInterval(() => {
+    const oneSignal = getOneSignalInstance();
+    if (oneSignal) {
+      setInitialized(true);
+      callback();
+    }
+  }, initialized ? null : pollingIntervalMs);
+};
+
+/**
  * Object for manipulating OneSignal.
  */
 const ReactOneSignal = {
@@ -480,6 +502,7 @@ const ReactOneSignal = {
   getExternalUserId,
   sendTag,
   sendTags,
+  useOneSignalSetup,
 };
 
 export default ReactOneSignal;

--- a/package/src/oneSignal.ts
+++ b/package/src/oneSignal.ts
@@ -465,6 +465,7 @@ const sendTags = (keyValues: object) => new Promise<string>((resolve, reject) =>
  * Object for manipulating OneSignal.
  */
 const ReactOneSignal = {
+  getOneSignalInstance,
   initialize,
   notificationPermission,
   getNotificationPermission,


### PR DESCRIPTION
I've been having problems with service worker taking a long time and I have to wait for it before I call setEmail or setExternalUserId

So I propose a hook to poll if OneSignal is initialized and when it is, run the setup callback with setEmail/logoutEmail etc.

This way, unhandled promise rejection is easier to avoid due to "OneSignal is not setup correctly." error